### PR TITLE
updated vignette and readme with format_publications function issue #110

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,22 @@ compare_scholar_careers(ids)
 
 ## Predicting future h-index values
 
-Finally users can predict the future [h-index](http://en.wikipedia.org/wiki/H-index) of a scholar, based on the method of [Acuna et al.](https://www.nature.com/nature/articles/489201a).  Since the method was originally calibrated on data from neuroscientists, it goes without saying that, if the scholar is from another discipline, then the results should be taken with a large pinch of salt.  A more general critique of the original paper is available   [here](http://simplystatistics.org/2012/10/10/whats-wrong-with-the-predicting-h-index-paper/).  Still, it's a bit of fun.  
+Users can predict the future [h-index](http://en.wikipedia.org/wiki/H-index) of a scholar, based on the method of [Acuna et al.](https://www.nature.com/nature/articles/489201a).  Since the method was originally calibrated on data from neuroscientists, it goes without saying that, if the scholar is from another discipline, then the results should be taken with a large pinch of salt.  A more general critique of the original paper is available   [here](http://simplystatistics.org/2012/10/10/whats-wrong-with-the-predicting-h-index-paper/).  Still, it's a bit of fun.  
 
 ```
 ## Predict h-index of original method author, Daniel Acuna
 id <- 'GAi23ssAAAAJ'
 predict_h_index(id)
+```
+
+## Formatting publications for CV
+
+Finally, the `format_publications` function can be used (e.g., in conjunction with the [`vitae`](https://pkg.mitchelloharawild.com/vitae/) package) to format publications in APA Style. The short name of the author of interest (e.g., of the person whose CV is being made) can be highlighted in bold with the `author.name` argument. The function after the pipe allows rmarkdown to format them properly, and the code chunk should be set to `results = "asis"`.
+
+```
+# APA style:
+format_publications("NrfwEncAAAAJ", "R Thériault") |> cat(sep='\n\n')
+
+# Numbering format:
+format_publications("NrfwEncAAAAJ", "R Thériault") |> print(quote=FALSE)
 ```

--- a/vignettes/scholar.Rmd
+++ b/vignettes/scholar.Rmd
@@ -38,7 +38,7 @@ id <- 'B7vSqZsAAAAJ'
 ## Get his profile
 l <- get_profile(id)
 
-## Print his name and affliation
+## Print his name and affiliation
 l$name
 l$affiliation
 
@@ -94,6 +94,7 @@ ggplot(ach, aes(year, cites)) +
 ```
 
 # Comparing scholars
+
 You can compare the citation history of scholars by fetching data with 
 `compare_scholars`.
 ```{r}
@@ -132,3 +133,20 @@ plot_coauthors(coauthor_network)
 ```
 
 Note however, that these are the coauthors listed in Google Scholar profile and not coauthors from all publications.
+
+# Formatting publications for CV
+
+The `format_publications` function can be used for example in conjunction with the [`vitae`](https://pkg.mitchelloharawild.com/vitae/) package to format publications in APA Style. The short name of the author of interest (e.g., of the person whose CV is being made) can be highlighted in bold with the `author.name` argument. The function after the pipe allows rmarkdown to format them properly, and the code chunk should be set to `results = "asis"`.
+
+### APA style
+
+```{r  results = "asis"}
+format_publications("NrfwEncAAAAJ", "R Thériault") |> cat(sep='\n\n')
+
+```
+
+### Numbering format
+
+```{r  results = "asis"}
+format_publications("NrfwEncAAAAJ", "R Thériault") |> print(quote=FALSE)
+```


### PR DESCRIPTION
Ok this is my first vignette AND my first PR so I'd welcome any feedback to improve but also please modify as needed.

After cloning the repository (the YuLab-SMU one, since that's the one containing the new function), I realized you already had one vignette in `/vignettes`. That's interesting because I never saw it before and trying to fetch it within R gives the following:
```r
vignette("scholar")
Warning message:
vignette ‘scholar’ not found 
```
In any case, I just edited the existing vignette with the added demonstration. I also edited the readme since that's what most people are likely to find.

Also, at first I used Richard Feynman's profile but at some point it produced an error because of too many publications:
```r
Error in `mutate()`:
! Problem while computing `author = get_complete_authors(scholar.profile, pubid)`.
Caused by error in `get_complete_authors()`:
Requesting author lists for more than 50 publications risks google identifying you as a bot and blocking your ip range (429 errors)
```

So I went back to using my profile since I have so few. But feel free to change to whatever other person.